### PR TITLE
Property Templates: Missing "AllowEmptyValue" and "Tag Path"

### DIFF
--- a/content/pi-event-frames-interface-manager/templates-tab/property-templates-efim.md
+++ b/content/pi-event-frames-interface-manager/templates-tab/property-templates-efim.md
@@ -52,6 +52,14 @@ Populates the tag's Descriptor field.
     
 Unit of measurement. 
 
-### Category
+### Select category
     
-Specifies the PI AF category to be associated with the value. 
+Specifies the PI AF category to be associated with the value.
+
+### AllowEmptyValue
+
+<!-- Help wanted -->
+
+### Tag Path
+
+<!-- Help wanted -->


### PR DESCRIPTION
Hi Team,

I found a gap in the docs around two options for property templates: AllowEmptyValue and Tag path. What's the purpose of these two options?